### PR TITLE
Desktop App: Change Input Field Text

### DIFF
--- a/src/renderer/components/pages/ConfirmAccessCodePage.jsx
+++ b/src/renderer/components/pages/ConfirmAccessCodePage.jsx
@@ -24,7 +24,7 @@ export function ConfirmAccessCodeForm({ touched, errors }) {
               role="accessCode"
               name="accessCode"
               placeholder="XXXXXX"
-              className="w-96 py-2 pl-2 m-0 rounded-lg text-left"
+              className="w-96 py-2 pl-2 m-0 rounded-lg text-left text-desktopBgBlack"
             />
 
             { touched.accessCode


### PR DESCRIPTION
Fixes #41 
Input field text should be black, not white
[Figma](https://www.figma.com/file/saSl8LVUCEYpptPsvyGGHq/Insights-Agent?node-id=906%3A785&t=uPvmrrJe2CZEHnJe-0)

- [x] Change text color

Currently:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/92892101/206581958-ec21c4f3-3a96-41fc-b340-ee787c806d73.png">

### After:
<img width="464" alt="Screenshot 2022-12-12 at 10 44 34 AM" src="https://user-images.githubusercontent.com/59852686/207104005-b7020b68-4a9a-4e29-84ad-25ec5e909c26.png">
